### PR TITLE
解决无法随taro开发模式自动关闭的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,10 @@ export default (ctx, pluginOpts) => {
         ]
       })
       await server.start()
+      process.on('SIGINT', function () {
+        console.log('数据 mock 服务已关闭.');
+        process.exit();
+      });
     }
     isFirstWatch = false
   })


### PR DESCRIPTION
针对ISSUES 
[mock服务无法随开发服务一起关闭，第二次开启会报端口占用错误 ](https://github.com/NervJS/taro-plugin-mock/issues/1)
