### PR TITLE
fix: swc compatibility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,10 @@ export function getMockConfigs ({
     })
     if (mockFiles.length) {
       const absMockFiles = mockFiles.map(file => path.join(mockDir, file))
-      helper.createBabelRegister({
+      let createRegister;
+      if ('createBabelRegister' in helper) createRegister = helper.createBabelRegister
+      if ('createSwcRegister' in helper) createRegister = helper.createSwcRegister
+      createRegister({
         only: absMockFiles
       })
       absMockFiles.forEach(absFile => {


### PR DESCRIPTION
if only babel register, this plugin can't be compatible with swc compiler. this pull request will fix it.